### PR TITLE
Concurrent request list processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 json_rpc_toolkit-*.tar
 
+/.elixir_ls/

--- a/lib/json_rpc/application.ex
+++ b/lib/json_rpc/application.ex
@@ -1,0 +1,18 @@
+defmodule JSONRPC.Application do
+  @moduledoc """
+  Basic Application Supervisor
+  """
+
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {Task.Supervisor, name: JSONRPC.TaskSupervisor}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: JSONRPC.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/json_rpc/channel.ex
+++ b/lib/json_rpc/channel.ex
@@ -2,7 +2,7 @@ if Code.ensure_loaded?(Phoenix.Channel) do
   defmodule JSONRPC.Channel do
     use Phoenix.Channel
     alias Phoenix.Socket
-    alias JSONRPC.{Parser, Request}
+    alias JSONRPC.{Parser, Request, Response}
 
     def join("jsonrpc", _message, socket) do
       {:ok, socket}
@@ -19,11 +19,20 @@ if Code.ensure_loaded?(Phoenix.Channel) do
       end
     end
 
-    defp handle_message(requests, params, registry) when is_list(requests) do
-      Enum.map(requests, &handle_message(&1, params, registry))
+    def handle_message(requests, params, registry) when is_list(requests) do
+      Task.Supervisor.async_stream_nolink(
+        JSONRPC.TaskSupervisor,
+        requests,
+        __MODULE__,
+        :handle_message,
+        [params, registry],
+        [ordered: true, timeout: 5000, on_timeout: :kill_task]
+      )
+      |> Enum.zip(requests)
+      |> Enum.map(&Response.finalize_async_response/1)
     end
 
-    defp handle_message(request, params, registry) do
+    def handle_message(request, params, registry) do
       registry
       |> apply(:call, [request, [connection_params: params]])
       |> Request.to_response()

--- a/lib/json_rpc/channel.ex
+++ b/lib/json_rpc/channel.ex
@@ -1,7 +1,6 @@
 if Code.ensure_loaded?(Phoenix.Channel) do
   defmodule JSONRPC.Channel do
     use Phoenix.Channel
-    alias Phoenix.Socket
     alias JSONRPC.{Parser, Request, Response}
 
     def join("jsonrpc", _message, socket) do
@@ -11,7 +10,7 @@ if Code.ensure_loaded?(Phoenix.Channel) do
     def handle_in("jsonrpc", message, socket) do
       message
       |> Parser.parse()
-      |> handle_message(socket.assigns.connection_params, socket.assigns.registry)
+      |> handle_message(socket.assigns.connection_params, socket.assigns.registry, socket.assigns.timeout)
       |> case do
         [_, _] = responses -> {:reply, {:ok, Enum.reject(responses, &is_nil/1)}, socket}
         %{error: nil} = response -> {:reply, {:ok, response}, socket}
@@ -19,20 +18,20 @@ if Code.ensure_loaded?(Phoenix.Channel) do
       end
     end
 
-    def handle_message(requests, params, registry) when is_list(requests) do
+    def handle_message(requests, params, registry, timeout) when is_list(requests) do
       Task.Supervisor.async_stream_nolink(
         JSONRPC.TaskSupervisor,
         requests,
         __MODULE__,
         :handle_message,
         [params, registry],
-        [ordered: true, timeout: 5000, on_timeout: :kill_task]
+        [ordered: true, timeout: timeout, on_timeout: :kill_task]
       )
       |> Enum.zip(requests)
       |> Enum.map(&Response.finalize_async_response/1)
     end
 
-    def handle_message(request, params, registry) do
+    def handle_message(request, params, registry, _timeout) do
       registry
       |> apply(:call, [request, [connection_params: params]])
       |> Request.to_response()

--- a/lib/json_rpc/response.ex
+++ b/lib/json_rpc/response.ex
@@ -25,4 +25,12 @@ defmodule JSONRPC.Response do
   def new(_) do
     %Response{error: Error.internal_error()}
   end
+
+  def finalize_async_response({{:ok, value}, _}), do: value
+  def finalize_async_response({_, request}) do
+    %Response{
+      id: request.id,
+      error: JSONRPC.Error.internal_error()
+    }
+  end
 end

--- a/lib/json_rpc/socket.ex
+++ b/lib/json_rpc/socket.ex
@@ -2,6 +2,7 @@ if Code.ensure_loaded?(Phoenix.Transports.WebSocket) do
   defmodule JSONRPC.Socket do
     defmacro __using__(opts) do
       registry = Keyword.get(opts, :registry)
+      timeout = Keyword.get(opts, :timeout, 5000)
 
       quote do
         use Phoenix.Socket
@@ -16,6 +17,7 @@ if Code.ensure_loaded?(Phoenix.Transports.WebSocket) do
             socket
             |> Phoenix.Socket.assign(:connection_params, params)
             |> Phoenix.Socket.assign(:registry, @registry)
+            |> Phoenix.Socket.assign(:timeout, unquote(timeout))
 
           {:ok, socket}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule JsonRpcToolkit.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {JSONRPC.Application, []}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JsonRpcToolkit.MixProject do
   def project do
     [
       app: :json_rpc_toolkit,
-      version: "0.9.14",
+      version: "0.10.0",
       name: "json_rpc_toolkit",
       description: "A transport agnostic JSON-RPC library with support for Phoenix",
       elixir: "~> 1.8",


### PR DESCRIPTION
Addresses [[ch17892]](https://app.clubhouse.io/versus-systems/story/17892/json-rpc-toolkit-can-process-lists-of-requests-concurrently)

Supports in both the Plug and the Channel the idea of concurrently processing lists of requests using supervised task processes.